### PR TITLE
feat: add output-dir option for custom script directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /.luarc.json
 .DS_Store
 /docs/_site
+
+# Generated script files from ripper extension demos
+/docs/*.R
+/docs/*.py
+/docs/scripts/
+/docs/*_files/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Render your document with Quarto:
 quarto render my-analysis.qmd
 ```
 
-Extracted scripts will be created in the same directory with names based on your document file name, e.g.
+Extracted scripts will be created in the same directory (or a custom directory via `output-dir`) with names based on your document file name, e.g.
 
 - `my-analysis.R` - All R code extracted
 - `my-analysis.py` - All Python code extracted
@@ -66,6 +66,7 @@ extensions:
     include-yaml: true               # Include YAML as comments (default: true)
     script-links-position: "bottom"  # Position of links section (default: "bottom")
     output-name: "my-scripts"        # Custom base name for output files (optional)
+    output-dir: "scripts"            # Directory to save scripts (optional)
     debug: false                     # Enable verbose logging (default: false)
 ---
 ```
@@ -119,6 +120,23 @@ Some introductory text here.
 - For example, if you set `output-name: "my-custom-name"`, rendering `my-analysis.qmd` would produce:
   - `my-custom-name.R`
   - `my-custom-name.py`
+
+#### Option: `output-dir`
+
+- Specifies a directory where generated script files should be saved.
+- Paths are relative to the document location.
+- The directory is created automatically if it doesn't exist.
+- Use `../` to navigate up from the document directory.
+
+##### Examples
+
+```yaml
+# Save scripts to a 'scripts' folder next to the document
+output-dir: "scripts"
+
+# Save scripts to project root when document is in docs/
+output-dir: "../scripts"
+```
 
 #### Option: `debug`
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -21,6 +21,8 @@ website:
         contents:
         - text: "Default Configuration"
           file: qripper-default-config.qmd
+        - text: "Custom Output Directory"
+          file: qripper-output-dir.qmd
         - text: "Custom Placement"
           file: qripper-custom-placement.qmd
         - text: "RevealJS Presentation"

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -49,7 +49,7 @@ Render your document with Quarto:
 quarto render my-analysis.qmd
 ```
 
-Extracted scripts will be created in the same directory with names based on your document file name, e.g.
+Extracted scripts will be created in the same directory (or a custom directory via `output-dir`) with names based on your document file name, e.g.
 
 - `my-analysis.R` - All R code extracted
 - `my-analysis.py` - All Python code extracted
@@ -72,6 +72,7 @@ extensions:
     include-yaml: true               # Include YAML as comments (default: true)
     script-links-position: "bottom"  # Position of links section (default: "bottom")
     output-name: "my-scripts"        # Custom base name for output files (optional)
+    output-dir: "scripts"            # Directory to save scripts (optional)
     debug: false                     # Enable verbose logging (default: false)
 ---
 ```
@@ -125,6 +126,23 @@ Some introductory text here.
 - For example, if you set `output-name: "my-custom-name"`, rendering `my-analysis.qmd` would produce:
   - `my-custom-name.R`
   - `my-custom-name.py`
+
+#### Option: `output-dir`
+
+- Specifies a directory where generated script files should be saved.
+- Paths are relative to the document location.
+- The directory is created automatically if it doesn't exist.
+- Use `../` to navigate up from the document directory.
+
+##### Examples
+
+```yaml
+# Save scripts to a 'scripts' folder next to the document
+output-dir: "scripts"
+
+# Save scripts to project root when document is in docs/
+output-dir: "../scripts"
+```
 
 #### Option: `debug`
 

--- a/docs/qripper-output-dir.qmd
+++ b/docs/qripper-output-dir.qmd
@@ -1,0 +1,67 @@
+---
+title: "Custom Output Directory"
+format: html
+extensions:
+  ripper:
+    output-dir: scripts
+filters:
+  - ripper
+---
+
+## Overview
+
+This document demonstrates the `output-dir` option, which saves generated scripts to a separate directory instead of alongside the source document.
+
+The document configuration is:
+
+````markdown
+---
+title: "Custom Output Directory"
+format: html
+extensions:
+  ripper:
+    output-dir: scripts
+filters:
+  - ripper
+---
+````
+
+With this configuration, the extracted scripts will be saved to a `scripts/` folder relative to this document's location. The directory is created automatically if it doesn't exist.
+
+### Common Patterns
+
+**Save to a scripts folder next to the document:**
+
+```yaml
+output-dir: "scripts"
+```
+
+**Save to project root when document is in a subdirectory:**
+
+```yaml
+# If document is in docs/, this saves to project-root/scripts/
+output-dir: "../scripts"
+```
+
+**Combine with custom output name:**
+
+```yaml
+output-dir: "scripts"
+output-name: "analysis"  # Creates scripts/analysis.R, scripts/analysis.py
+```
+
+## R Code
+
+```{r}
+#| label: r-example
+data <- mtcars
+summary(data$mpg)
+```
+
+## Python Code
+
+```{python}
+#| label: python-example
+numbers = [1, 2, 3, 4, 5]
+print(f"Sum: {sum(numbers)}")
+```


### PR DESCRIPTION
## Summary

- Add new `output-dir` configuration option that allows users to specify a custom directory for generated script files
- Directory paths are relative to the document location and support `../` navigation
- Directories are automatically created if they don't exist
- Uses Pandoc's cross-platform filesystem API for Windows compatibility

## Usage

```yaml
extensions:
  ripper:
    output-dir: scripts         # Creates scripts/ next to document
    output-dir: ../scripts      # Creates scripts/ at project root
```

## Test plan

- [x] Verified scripts are created in specified directory
- [x] Verified directory is auto-created if missing
- [x] Verified relative paths with `../` work correctly
- [x] Verified script links in rendered document point to correct path
- [x] Verified existing behavior unchanged when option not set
- [x] Rendered new demo page successfully

Closes #2